### PR TITLE
Made Future Soldier's Paradrop ability more loyal to BNW

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -74,11 +74,11 @@
 	},
 	{
 		"name": "Paradrop",
-		"uniques": ["May Paradrop up to [9] tiles from inside friendly territory",]
+		"uniques": ["May Paradrop up to [9] tiles from inside friendly territory <for units without [Skyranger]>",]
 	},
 	{
 		"name": "Skyranger",
-		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory",]
+		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory","May Paradrop up to [49] tiles from inside friendly territory <for units with [Paradrop]>"]
 	},
 	{
 		"name": "Altitude Training",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -74,11 +74,11 @@
 	},
 	{
 		"name": "Paradrop",
-		"uniques": ["May Paradrop up to [9] tiles from inside friendly territory <for units without [Skyranger]>",]
+		"uniques": ["Comment [May Paradrop up to 9 tiles from inside friendly territory]", "May Paradrop up to [9] tiles from inside friendly territory <for units without [Skyranger]> <hidden from users>"]
 	},
 	{
 		"name": "Skyranger",
-		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory","May Paradrop up to [49] tiles from inside friendly territory <for units with [Paradrop]>"]
+		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory","May Paradrop up to [49] tiles from inside friendly territory <for units with [Paradrop]> <hidden from users>"]
 	},
 	{
 		"name": "Altitude Training",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -73,6 +73,14 @@
 		"uniques": ["[+50]% Strength <when fighting in [Desert] tiles>"]
 	},
 	{
+		"name": "Paradrop",
+		"uniques": ["May Paradrop up to [9] tiles from inside friendly territory",]
+	},
+	{
+		"name": "Skyranger",
+		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory",]
+	},
+	{
 		"name": "Altitude Training",
 		"uniques": ["Double movement in [Hill]","[+10]% Strength <when fighting in [Hill] tiles>"]
 	},

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -260,7 +260,8 @@
 		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Future Soldier",
-		"uniques": ["May Paradrop up to [9] tiles from inside friendly territory", "No movement cost to pillage", "Never appears as a Barbarian unit"],
+		"promotions": ["Paradrop"],
+		"uniques": ["No movement cost to pillage", "Never appears as a Barbarian unit"],
 		"attackSound": "shot"
 	},
 	{
@@ -270,7 +271,8 @@
 		"strength": 100,
 		"cost": 400,
 		"requiredTech": "Nanotechnology",
-		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory", "Never appears as a Barbarian unit"],
+		"promotions": ["Skyranger"],
+		"uniques": ["Never appears as a Barbarian unit"],
 		"attackSound": "shot"
 	},
 	{


### PR DESCRIPTION
The Future Soldier/XCOM Squad unit in BNW can have its 'Skyranger' ability stack with the regular Paratrooper ability. This means that Paratroopers that are upgraded to Future Soldiers can paradrop up to 49 tiles, while regular Future Soldiers can only paradrop up to 40 tiles.
(https://civilization.fandom.com/wiki/XCOM_Squad_(Civ5))