### PR TITLE
Germany, Iroquois and India changes

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -152,6 +152,7 @@
 		"uniques": [
 			"Provides [2] [Tourism] <after discovering [Flight]>"
 		],
+		"requiredBuilding": "Walls",
 		"requiredTech": "Chivalry"
 	},
 	{

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -142,6 +142,19 @@
 		"requiredTech": "Writing"
 	},
 	{
+		"name": "Mughal Fort",
+		"replaces": "Castle",
+		"uniqueTo": "India",
+		"hurryCostModifier": 25,
+		"cityHealth" : 25,
+		"cityStrength" : 7,
+		"culture" : 2,
+		"uniques": [
+			"Provides [2] [Tourism] <after discovering [Flight]>"
+		],
+		"requiredTech": "Chivalry"
+	},
+	{
 		"name": "Amphitheater",
 		"culture": 1,
 		"requiredBuilding": "Monument",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -423,6 +423,43 @@
 			"Kamakura","Kochi","Naha","Sendai","Gifu","Yamaguchi","Ota","Tottori"]
 	},
 
+ {
+        "name": "Germany",
+        "leaderName": "Otto von Bismarck",
+        "adjective": ["German"],
+        "startBias": ["Avoid [Coast]"],
+        "preferredVictoryType": "Scientific",
+	 
+        "startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+        "startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+	 
+        "declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
+        "attacked": "Corrupted villain! We will bring you into the ground!",
+        "defeated": "Germany has been destroyed. I weep for the future generations.",
+        "introduction": "Guten tag. In the name of the great German people, I bid you welcome.",
+        "neutralHello": "What now?",
+        "hateHello": "So, out with it!",
+        "tradeRequest": "It would be in your best interest, to carefully consider this proposal.",
+        "outerColor": [150,150,150],
+        "innerColor": [60,60,60],
+        "uniqueName": "Furor Teutonicus",
+        "uniques": [
+            "When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [67]% chance>",
+			"[-25]% maintenance costs" //Should just be for Land units
+		],
+        "cities": [
+            "Berlin","Hamburg","Munich","Cologne","Frankfurt","Essen","Dortmund","Stuttgart","Dusseldorf","Bremen",
+            "Hannover","Duisburg","Leipzig","Dresden","Bonn","Bochum","Bielefeld","Karlsruhe","Gelsenkirchen","Wiesbaden",
+            "Munster","Rostok","Chemnitz","Braunschweig","Halle","Monchengladbach","Kiel","Wuppertal","Freiburg","Hagen",
+            "Erfurt","Kassel","Oberhausen","Hamm","Saarbrucken","Krefeld","Potsdam","Solingen","Osnabruck","Ludwingshafen",
+            "Leverkusen","Oldenburg","Neuss","Mulheim","Darmstadt","Herne","Wurzburg","Recklinghausen","Gottingen","Wolfsburg",
+            "Koblenz","Hildesheim","Erlangen"
+        ],
+        "spyNames": [
+            "Johann","Marlene","Wilhelm","Eva","Heinz","Horst","Carl","Viper","Albrecht","Anton"
+        ]
+    },
+
 	// City-States sorted by cityStateType, name
 
 	{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -432,14 +432,15 @@
         "adjective": ["German"],
         "startBias": ["Avoid [Coast]"],
         "preferredVictoryType": "Scientific",
-	 
+		"personality": "Otto von Bismarck",
+
         "startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
         "startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 	 
         "declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
         "attacked": "Corrupted villain! We will bring you into the ground!",
         "defeated": "Germany has been destroyed. I weep for the future generations.",
-	 //denounced?
+        "denounced": "That boldness is risky, especially if you lack the strength to back it up.",
         "introduction": "Guten tag. In the name of the great German people, I bid you welcome.",
         "neutralHello": "What now?",
         "hateHello": "So, out with it!",
@@ -450,7 +451,7 @@
         "uniqueName": "Furor Teutonicus",
         "uniques": [
             "When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [67]% chance>",
-			"[-25]% maintenance costs" //Should just be for Land units
+			"[-25]% maintenance costs <for [Land] units>"
 		],
 	    "spyNames": ["Johann","Marlene","Wilhelm","Eva","Heinz","Horst","Carl","Viper","Albrecht","Anton",]
         "cities": [ "Berlin","Hamburg","Munich","Cologne","Frankfurt","Essen","Dortmund","Stuttgart","Dusseldorf","Bremen",
@@ -467,14 +468,15 @@
         "adjective": ["Irochese"],
         "startBias": ["Avoid [Coast]","Forest"],
         "preferredVictoryType": "Scientific",
-	
+		"personality": "Hiawatha",
+
         "startIntroPart1": "Greetings, noble Hiawatha, leader of the mighty Iroquois nations! Long have your people lived near the great and holy lake Ontario in the land that has come to be known as the New York state in North America. In the mists of antiquity, the five peoples of Seneca, Onondaga, Mohawks, Cayugas and Oneida united into one nation, the Haudenosaunee, the Iroquois. With no written language, the wise men of your nation created the great law of peace, the model for many contitutions including that of the United States. For many years, your people battled great enemies, such as the Huron, and the French and English invaders. Tought outnumbered and facing weapons far more advanced than the ones your warriors wielded, the Iroquois survived and prospered, until they were finally overwhelmed by the mighty armies of the new United States.",
         "startIntroPart2": "Oh noble Hiawatha, listen to the cries of your people! They call out to you to lead them in peace and war, to rebuild the great longhouse and unite the tribes once again. Will you accept this challenge, great leader? Will you build a civilization that will stand the test of time?",
 	
         "declaringWar": "You are a plague upon Mother Earth! Prepare for battle!",
         "attacked": "You evil creature! My braves will slaughter you!",
         "defeated": "You have defeated us... but our spirits will never be vanquished! We shall return!",
-	//denounced?
+        "denounced": "Go back to the shadows, you fool.",
         "introduction": "Greetings, stranger. I am Hiawatha, speaker for the Iroquois. We seek peace with all, but we do not shrink from war.",
         "neutralHello": "Good day.",
         "hateHello": "Oh, it's you.",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -350,10 +350,11 @@
 			"[+10]% Spread Religion Strength", // TODO: Your Trade Routes spread the home city's Religion twice as effectively
 			"Double quantity of [Oil] produced"
 		],
+		"spyNames": ["Solhofaat", "Khenzeer", "Zarafah", "Temsaah", "Abyadh", "Mostafa", "Yusuf", "Waddah", "Sameera", "Gamal"]
 		"cities": ["Mecca","Medina","Damascus","Baghdad","Najran","Kufah","Basra","Khurasan","Anjar","Fustat",
 			"Aden","Yamama","Muscat","Mansura","Bukhara","Fez","Shiraz","Merw","Balkh","Mosul",
 			"Aydab","Bayt","Suhar","Taif","Hama","Tabuk","Sana'a","Shihr","Tripoli","Tunis","Kairouan","Algiers","Oran"],
-        "spyNames": ["Solhofaat", "Khenzeer", "Zarafah", "Temsaah", "Abyadh", "Mostafa", "Yusuf", "Waddah", "Sameera", "Gamal"]
+       
     },
 	{
 		"name": "France",
@@ -383,11 +384,12 @@
 			// Double Museum Tourism production in capital @see Museum
 			// TODO: World Wonder theming bonuses are doubled in their Capital.
 		],
+		"spyNames": ["Jean-Paul", "Martine", "Lucien", "François", "Augustine", "Monsieur X", "Dr. Dupont", "Vipère", "Yvette", "Renard"]
 		"cities": ["Paris","Orleans","Lyon","Troyes","Tours","Marseille","Chartres","Avignon","Rouen","Grenoble",
 			"Dijon","Amiens","Cherbourg","Poitiers","Toulouse","Bayonne","Strasbourg","Brest","Bordeaux","Rennes",
 			"Nice","Saint Etienne","Nantes","Reims","Le Mans","Montpellier","Limoges","Nancy","Lille","Caen","Toulon",
 			"Le Havre","Lourdes","Cannes","Aix-En-Provence","La Rochelle","Bourges","Calais"],
-        "spyNames": ["Jean-Paul", "Martine", "Lucien", "François", "Augustine", "Monsieur X", "Dr. Dupont", "Vipère", "Yvette", "Renard"]
+        
     },
 
 	{
@@ -417,6 +419,7 @@
 			"[+1 Culture] from every [Fishing Boats]",
 			"[+2 Culture] from every [Atoll]"
 		],
+		"spyNames": ["Akaishi","Oki","Hattori","Morozumi","Momochi","Kawashima","Orin","Sakanishi","Kaede","Mochizuki",]
 		"cities": ["Kyoto","Osaka","Tokyo","Satsuma","Kagoshima","Nara","Nagoya","Izumo","Nagasaki","Yokohama",
 			"Shimonoseki","Matsuyama","Sapporo","Hakodate","Ise","Toyama","Fukushima","Suo","Bizen","Echizen",
 			"Izumi","Omi","Echigo","Kozuke","Sado","Kobe","Nagano","Hiroshima","Takayama","Akita","Fukuoka","Aomori",
@@ -447,17 +450,14 @@
             "When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [67]% chance>",
 			"[-25]% maintenance costs" //Should just be for Land units
 		],
-        "cities": [
-            "Berlin","Hamburg","Munich","Cologne","Frankfurt","Essen","Dortmund","Stuttgart","Dusseldorf","Bremen",
+	    "spyNames": ["Johann","Marlene","Wilhelm","Eva","Heinz","Horst","Carl","Viper","Albrecht","Anton",]
+        "cities": [ "Berlin","Hamburg","Munich","Cologne","Frankfurt","Essen","Dortmund","Stuttgart","Dusseldorf","Bremen",
             "Hannover","Duisburg","Leipzig","Dresden","Bonn","Bochum","Bielefeld","Karlsruhe","Gelsenkirchen","Wiesbaden",
             "Munster","Rostok","Chemnitz","Braunschweig","Halle","Monchengladbach","Kiel","Wuppertal","Freiburg","Hagen",
             "Erfurt","Kassel","Oberhausen","Hamm","Saarbrucken","Krefeld","Potsdam","Solingen","Osnabruck","Ludwingshafen",
             "Leverkusen","Oldenburg","Neuss","Mulheim","Darmstadt","Herne","Wurzburg","Recklinghausen","Gottingen","Wolfsburg",
-            "Koblenz","Hildesheim","Erlangen"
-        ],
-        "spyNames": [
-            "Johann","Marlene","Wilhelm","Eva","Heinz","Horst","Carl","Viper","Albrecht","Anton"
-        ]
+            "Koblenz","Hildesheim","Erlangen"]
+        
     },
 
 	// City-States sorted by cityStateType, name

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -439,12 +439,14 @@
         "declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
         "attacked": "Corrupted villain! We will bring you into the ground!",
         "defeated": "Germany has been destroyed. I weep for the future generations.",
+	 //denounced?
         "introduction": "Guten tag. In the name of the great German people, I bid you welcome.",
         "neutralHello": "What now?",
         "hateHello": "So, out with it!",
         "tradeRequest": "It would be in your best interest, to carefully consider this proposal.",
         "outerColor": [150,150,150],
         "innerColor": [60,60,60],
+	    "favoredReligion": "Protestantism",
         "uniqueName": "Furor Teutonicus",
         "uniques": [
             "When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [67]% chance>",
@@ -457,7 +459,39 @@
             "Erfurt","Kassel","Oberhausen","Hamm","Saarbrucken","Krefeld","Potsdam","Solingen","Osnabruck","Ludwingshafen",
             "Leverkusen","Oldenburg","Neuss","Mulheim","Darmstadt","Herne","Wurzburg","Recklinghausen","Gottingen","Wolfsburg",
             "Koblenz","Hildesheim","Erlangen"]
-        
+    },
+
+{
+        "name": "Iroquois",
+        "leaderName": "Hiawatha",
+        "adjective": ["Irochese"],
+        "startBias": ["Avoid [Coast]","Forest"],
+        "preferredVictoryType": "Scientific",
+	
+        "startIntroPart1": "Greetings, noble Hiawatha, leader of the mighty Iroquois nations! Long have your people lived near the great and holy lake Ontario in the land that has come to be known as the New York state in North America. In the mists of antiquity, the five peoples of Seneca, Onondaga, Mohawks, Cayugas and Oneida united into one nation, the Haudenosaunee, the Iroquois. With no written language, the wise men of your nation created the great law of peace, the model for many contitutions including that of the United States. For many years, your people battled great enemies, such as the Huron, and the French and English invaders. Tought outnumbered and facing weapons far more advanced than the ones your warriors wielded, the Iroquois survived and prospered, until they were finally overwhelmed by the mighty armies of the new United States.",
+        "startIntroPart2": "Oh noble Hiawatha, listen to the cries of your people! They call out to you to lead them in peace and war, to rebuild the great longhouse and unite the tribes once again. Will you accept this challenge, great leader? Will you build a civilization that will stand the test of time?",
+	
+        "declaringWar": "You are a plague upon Mother Earth! Prepare for battle!",
+        "attacked": "You evil creature! My braves will slaughter you!",
+        "defeated": "You have defeated us... but our spirits will never be vanquished! We shall return!",
+	//denounced?
+        "introduction": "Greetings, stranger. I am Hiawatha, speaker for the Iroquois. We seek peace with all, but we do not shrink from war.",
+        "neutralHello": "Good day.",
+        "hateHello": "Oh, it's you.",
+        "tradeRequest": "Does this trade work for you, my friend?",
+        "outerColor": [54,72,72],
+        "innerColor": [246,205,137],
+		"favoredReligion": "Protestantism",
+        "uniqueName": "The Great Warpath",
+        "uniques": [
+			"All units move through Forest and Jungle Tiles in friendly territory as if they have roads. These tiles can be used to establish City Connections upon researching the Wheel.",
+			"Comment[Caravans move along Forest and Jungle as if they were Roads.]"
+		],
+	    "spyNames": ["Onatah","Oneida","Oshadagea","Otetiani","Genesee","Dadgayadoh","Otwtiani","Kateri","Onondakai","Honanyawus"],
+        "cities": ["Onoondaga","Osininka","Grand River","Akwesasme","Buffalo Creek","Brantford","Montreal","Genesse River","Canandaigua Lake","Lake Simcoe",
+            "Salamanca","Gowanda","Buffalo","Cuba","Akron","Kanesatake","Ganienkeh","Cayuga Castle","Chondote","Canajoharie",
+            "Nedrow","Syracuse","Oneida Lake","Kanonwalohale","Green Bay","Southwold","Mohawk Valley","Schoharie","Bay of Quinte","Kanawale",
+            "Kanatsiokareke","Tyendinaga","Hahta"] 
     },
 
 	// City-States sorted by cityStateType, name

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -10,6 +10,8 @@
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence <for units with [Caravansary Benefit]>",
 			// TODO: Establish Trade Route (Route must run over land from one city to another.)
 			// TODO: Change Home City (After selecting a city and waiting a turn, allows different trade routes to be made.)
+			"Double movement in [Jungle] <for [Iroquois] Civilizations> <hidden from users>",
+			"Double movement in [Forest] <for [Iroquois] Civilizations> <hidden from users>",
 			"Unavailable <for [City-States] Civilizations> <hidden from users>",
 			"Instantly consumes [1] [Trade Route]",
 			"Only available <with [Trade Route]> <hidden from users>",


### PR DESCRIPTION
- Increases Germany's chance of recruiting Barbarians from 50% to 67%
- Added -25% Maintenance costs for Germany
- Iroquois Caravans ignore terrain cost for Jungle and Forests
- India's Mughal Fort provides Tourism after Flight
- Added Spy Names for Japan
- Made the formatting for Spy Names a bit more consistent