### PR TITLE
Samurais now obsolete at Rifling instead of Gunpowder

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -11,7 +11,7 @@
 		"cost": 120,
 		"requiredTech": "Steel",
 		"upgradesTo": "Rifleman", // Musketman in Vanilla/G&K
-		"obsoleteTech": "Gunpowder",
+		"obsoleteTech": "Rifling",
 		"requiredResource": "Iron",
 		"promotions": ["Shock I", "Great Generals II"],
 		"uniques": ["Can build [Fishing Boats] improvements on tiles"],


### PR DESCRIPTION
This suppresses an in-game warning regarding how Samurai is supposed to be auto-upgraded at Gunpowder but the Rifleman may not yet be researched.