### PR TITLE
massive trade update

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -57,6 +57,7 @@
 		],
 		"requiredTech": "Radar"
 	},
+	// trade stuffs
 	{
 		"name": "Caravansary",
 		"cost": 120,
@@ -71,6 +72,104 @@
 				"text": "[Caravansary] ability",
 				"link": "Promotion/[Caravansary] ability"
 			}
+		]
+	},
+	{
+		"name": "Granary",
+		"food": 2,
+		"maintenance": 1,
+		"hurryCostModifier": 25,
+		"uniques": ["[+1 Food] from [Deer] tiles [in this city]",
+			"[+1 Food] from [Bananas] tiles [in this city]",
+			"[+1 Food] from [Wheat] tiles [in this city]",
+			"All newly-trained [Caravan] units [in this city] receive the [[Granary] ability] promotion",
+			"All newly-trained [Cargo Ship] units [in this city] receive the [[Granary] ability] promotion"
+		],
+		"requiredTech": "Pottery"
+	},
+	{
+		"name": "Food Bank",
+		"cost": 0,
+		"uniques": ["Unbuildable",
+			"Cannot be purchased",
+			"Destroyed when the city is captured",
+			"Instantly provides [1] [Trade Route]",
+			"Consumes [1] [Trade Route]",
+			"[+3 Food] [in this city] <during the [Ancient era]>",
+			"[+4 Food] [in this city] <starting from the [Classical era]> <before the [Industrial era]>",
+			"[+5 Food] [in this city] <during the [Industrial era]>",
+			"[+6 Food] [in this city] <starting from the [Modern era]>"
+		]
+	},
+	{
+		"name": "Food Entrepôt",
+		"cost": 0,
+		"uniques": ["Unbuildable",
+			"Cannot be purchased",
+			"Destroyed when the city is captured",
+			"Instantly provides [1] [Trade Route]",
+			"Consumes [1] [Trade Route]",
+			"[+6 Food] [in this city] <during the [Ancient era]>",
+			"[+8 Food] [in this city] <starting from the [Classical era]> <before the [Industrial era]>",
+			"[+10 Food] [in this city] <during the [Industrial era]>",
+			"[+12 Food] [in this city] <starting from the [Modern era]>"
+		]
+	},
+	{
+		"name": "Workshop",
+		"maintenance": 2,
+		"production": 2,
+		"specialistSlots": {"Engineer": 1},
+		"hurryCostModifier": 25,
+		"percentStatBonus": {"production": 10},
+		"uniques": [
+			"All newly-trained [Caravan] units [in this city] receive the [[Workshop] ability] promotion",
+			"All newly-trained [Cargo Ship] units [in this city] receive the [[Workshop] ability] promotion"
+		]
+		"requiredTech": "Metal Casting"
+	},
+	{
+		"name": "Longhouse",
+		"replaces": "Workshop",
+		"uniqueTo": "Iroquois",
+		"cost": 100,
+		"maintenance": 2,
+		"production": 2,
+		"specialistSlots": {"Engineer": 1},
+		"hurryCostModifier": 25,
+		"uniques": [
+			"[+1 Production] from [Forest] tiles [in this city]",
+			"All newly-trained [Caravan] units [in this city] receive the [[Workshop] ability] promotion",
+			"All newly-trained [Cargo Ship] units [in this city] receive the [[Workshop] ability] promotion"
+		],
+		"requiredTech": "Metal Casting"
+	},
+	{
+		"name": "Material Warehouse",
+		"cost": 0,
+		"uniques": ["Unbuildable",
+			"Cannot be purchased",
+			"Destroyed when the city is captured",
+			"Instantly provides [1] [Trade Route]",
+			"Consumes [1] [Trade Route]",
+			"[+3 Production] [in this city] <during the [Ancient era]>",
+			"[+4 Production] [in this city] <starting from the [Classical era]> <before the [Industrial era]>",
+			"[+5 Production] [in this city] <during the [Industrial era]>",
+			"[+6 Production] [in this city] <starting from the [Modern era]>"
+		]
+	},
+	{
+		"name": "Material Drydock",
+		"cost": 0,
+		"uniques": ["Unbuildable",
+			"Cannot be purchased",
+			"Destroyed when the city is captured",
+			"Instantly provides [1] [Trade Route]",
+			"Consumes [1] [Trade Route]",
+			"[+6 Production] [in this city] <during the [Ancient era]>",
+			"[+8 Production] [in this city] <starting from the [Classical era]> <before the [Industrial era]>",
+			"[+10 Production] [in this city] <during the [Industrial era]>",
+			"[+12 Production] [in this city] <starting from the [Modern era]>"
 		]
 	},
 	{

--- a/jsons/GlobalUniques.json
+++ b/jsons/GlobalUniques.json
@@ -16,5 +16,11 @@
 
 		// Great Admirals can always traverse ocean tiles
 		"Enables [Great Admiral] units to enter ocean tiles <hidden from users>"
+	],
+	"unitUniques": [
+		// plundering trade units give gold
+		// does this work on civvies?
+		"Gain [100] [Gold] <upon defeating a [Caravan] unit>",
+		"Gain [100] [Gold] <upon defeating a [Cargo Ship] unit>"
 	]
 }

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -170,7 +170,7 @@
 		"outerColor": [240,240,240],
 		"innerColor": [8,25,115],
 		"uniqueName": "Mare Clausum",
-		"uniqueText": "Resource diversity grants twice as much [Gold] for Portugal in [Trade Route]s."
+		"uniqueText": "Resource diversity grants twice as much [Gold] for Portugal in [Trade Route]s.",
 		"uniques": [
 			"[+100]% Gold from Great Merchant trade missions"
 		],
@@ -191,8 +191,8 @@
 
 		"startIntroPart1": "Honour be with you, oh great hero Gajah Mada, prime minister of Majapahit and uniter of the Indonesian archipelago. The stories of your heroism on the battlefield are bested only by the legends of your sworn oath to unite the far-flung islands of Indonesia under one banner. Serving your queen and empire with loyalty, you not only strive to fulfill your oath and conquered any who stood in your path, but you succeeded in capturing what was then the entirety of the known archipelago, the first to unite what is today modern Indonesia.",
 		"startIntroPart2": "Mighty warrior Gajah Mada, your people yearn for a strong leader who can return them to prosperity! Will you set out to conquer the neighboring kingdoms, further expanding your glory of your empire? Will you build a civilization that can stand the test of time?",
-		"declaringWar": "You stand between my army and their destiny... Prepare for war!",
-		"attacked": "You dare attack the great Gajah Mada?!",
+		"declaringWar": "You stand between my army and their destiny. I shall crush your head like a coconut!",
+		"attacked": "How dare you! Really insignificant as well!",
 		"defeated": "I'm impressed by your victory, even if it came at my expense.",
 		"denounced": "Your words ring hollow.",
 		"introduction": "You stand before the great Gajah Mada of Indonesia! What brings you to my empire?",
@@ -242,8 +242,17 @@
 		"outerColor": [123,3,0],
 		"innerColor": [40,179,79],
 		"uniqueName": "Gateway to Africa",
+		"uniqueText": "Receive +3 [Gold] and +1 [Culture] for 30 turns (on Standard speed) for each [Caravan] or [Cargo Ship] establishing a Trade Route with a City-State.",
 		"uniques": [
-			"[+1 Culture, +3 Gold] from each Trade Route", // Receives +3 Gold and +1 Culture for each Trade Route with a different civ or City-State.
+			// Receives +3 Gold and +1 Culture for each Trade Route with a different civ or City-State.
+			"[+3 Gold, +1 Culture] <for [30] turns> <on [Standard] game speed> <upon expending a [Caravan] unit>",
+			"[+3 Gold, +1 Culture] <for [30] turns> <on [Standard] game speed> <upon expending a [Cargo Ship] unit>",
+			"[+3 Gold, +1 Culture] <for [25] turns> <on [Quick] game speed> <upon expending a [Caravan] unit>",
+			"[+3 Gold, +1 Culture] <for [25] turns> <on [Quick] game speed> <upon expending a [Cargo Ship] unit>",
+			"[+3 Gold, +1 Culture] <for [45] turns> <on [Epic] game speed> <upon expending a [Caravan] unit>",
+			"[+3 Gold, +1 Culture] <for [45] turns> <on [Epic] game speed> <upon expending a [Cargo Ship] unit>",
+			"[+3 Gold, +1 Culture] <for [90] turns> <on [Marathon] game speed> <upon expending a [Caravan] unit>",
+			"[+3 Gold, +1 Culture] <for [90] turns> <on [Marathon] game speed> <upon expending a [Cargo Ship] unit>",
 			// TODO: Trade Route owners receive +2 Gold for each Trade Route sent to Morocco.
 			"Preferred Ideology: Freedom"
 		],
@@ -330,12 +339,12 @@
 		"personality": "Harun al-Rashid",
 
         "startIntroPart1": "Blessings of the Great God be upon you, O great caliph Harun al-Rashid, leader of the mighty Arabian people! The Muslim Empire, the Caliphate, born from chaos after the death of the prophet Muhammad in 632 AD, intended to apply the rule of God to all Earth. And by the will of God, the caliphate reached its full power, ruling Spain, North Africa, the Middle East, Anatolia, the Balkans and Persia, to even surpass the Great Roman Empire. The arts and sciences were a holy gift of Arabia during the Middle Ages, as the infidel lands of Europe delved deep into ignorance and chaos. Lasting for six hundred years, the Caliphate finally fell before the Mongols, the plague of the civilized world.",
-        "startIntroPart2": "Great Caliph Harun al Rashid, all Arabian people long for greatness! Arabia must be once again the land of arts and knowledge, which under the radiant law of God, will fear no enemy! Will your new empire shine through the ages of history?",
+        "startIntroPart2": "Great Caliph Harun al-Rashid, all Arabian people long for greatness! Arabia must be once again the land of arts and knowledge, which under the radiant law of God, will fear no enemy! Will your new empire shine through the ages of history?",
 
-        "declaringWar": "The world will be more beautiful without you. Prepare for war.",
-		"attacked": "Fool! You will soon regret dearly! I swear it!",
+        "declaringWar": "The world will be more beautiful without you. Prepare for war!",
+		"attacked": "Fool! You will soon regret this dearly! I swear it!",
 		"defeated": "You have won, congratulations. My palace is now in your possession, and I beg that you care well for the peacock.",
-		"denounced": "Well played, man. I am looking even more forward to our future battle!",
+		"denounced": "It is said by my people that the house of a tyrant is a ruin... and all I see is ruin around you.",
 		"introduction": "Welcome foreigner, I am Harun Al-Rashid, Caliph of the Arabs. Come and tell me about your empire.",
 		"neutralHello": "Peace be upon you.",
 		"hateHello": "Oh, it's you.",
@@ -348,7 +357,7 @@
 		"uniqueName": "Ships of the Desert",
 		"uniques": [
 			"Caravans gain 50% extended range", // @see Unit/Caravan
-			"[+10]% Spread Religion Strength", // TODO: Your Trade Routes spread the home city's Religion twice as effectively
+			"Comment [[Caravan] and [Cargo Ship] units may spread religion once]", // TODO: Your Trade Routes spread the home city's Religion twice as effectively
 			"[+100]% [Oil] resource production"
 			// TODO: Bazaar adds +1 Gold per incoming trade route (+1 for the owner of the trade route) https://civilization.fandom.com/wiki/Bazaar_(Civ5)
 		],

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -1076,8 +1076,10 @@
 				"name": "Iron Curtain",
 				"uniques": [
 					"Gain a free [Courthouse] [in this city] <upon conquering a city>", // TODO: Does this work?
-					"[+50]% [Food] from Trade Routes <in [Your] cities>", // TODO: Does this work? Should be for Internal trade routes
-					"[+50]% [Production] from Trade Routes <in [Your] cities>", // TODO: Does this work? Should be for Internal trade routes
+					"[+50]% [Food] from every [Food Bank]", // TODO: Does this work? Should be for Internal trade routes
+					"[+50]% [Food] from every [Food Entrepôt]",
+					"[+50]% [Production] from every [Material Warehouse]",
+					"[+50]% [Production] from every [Material Drydock]", // TODO: Does this work? Should be for Internal trade routes
 					"Instantly consumes [1] [Level 2 Policy] <hidden from users>",
 					"Only available <when above [1] [Level 2 Policy]> <hidden from users>"
 				],

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -180,6 +180,26 @@
 			{ "text": "Caravan", "link": "Unit/Caravan" }
 		]
 	},
+	{
+		"name": "[Granary] ability",
+		"uniques": [
+			"Comment [Allows establishing a [Food] [Trade Route] in your own cities]"
+		],
+		"civilopediaText": [
+			{ "text": "Caravan", "link": "Unit/Caravan" },
+			{ "text": "Cargo Ship", "link": "Unit/Cargo Ship" }
+		]
+	},
+	{
+		"name": "[Workshop] ability",
+		"uniques": [
+			"Comment [Allows establishing a [Production] [Trade Route] in your own cities]"
+		],
+		"civilopediaText": [
+			{ "text": "Caravan", "link": "Unit/Caravan" },
+			{ "text": "Cargo Ship", "link": "Unit/Cargo Ship" }
+		]
+	},
 
 	// Harbor
 	{

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -65,6 +65,7 @@
 		"requiredTech": "Animal Husbandry",
 		"uniques": [
 			"Comment [Can undertake a trade mission with City-State, giving a large sum of gold and [10] Influence]",
+			"Comment [If built in a city with a [Granary], may establish an Internal [Trade Route] in an owned city to provide extra [Food]]",
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [10] Influence <for units without [[Caravansary] ability]> <hidden from users>",
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [20] Influence <for units with [[Caravansary] ability]> <hidden from users>",
 			// TODO: Establish Trade Route (Route must run over land from one city to another.)
@@ -78,12 +79,16 @@
 			"Uncapturable <hidden from users>",
 			"Cannot embark",
 			"Never appears as a Barbarian unit <hidden from users>",
-			"[-66]% Gold from Great Merchant trade missions <hidden from users>"
-			// TODO: Within own cities, provide food and production after granary or workshop
+			"[-66]% Gold from Great Merchant trade missions <hidden from users>",
+			"Gain a free [Food Bank] [in this city] <by consuming this unit> <in [Your] cities> <in cities without a [Food Bank]> <for units with [[Granary] ability]> <hidden from users>",
+			"Gain a free [Material Warehouse] [in this city] <by consuming this unit> <in [Your] cities> <in cities without a [Material Warehouse]> <for units with [[Workshop] ability]> <hidden from users>",
+			// TODO: Within own cities, provide food and production after granary or workshop,
+			"Can Spread Religion <for all movement> <once> <after founding a religion> <for [Arabia] Civilizations> <hidden from users>"
 		],
 		"promotions": [
 			"The Great Warpath" // Iroquois unique
-		]
+		],
+		"religiousStrength": 1500
 	},
 	{
 		"name": "Cargo Ship", // https://civilization.fandom.com/wiki/Cargo_Ship_(Civ5)
@@ -93,6 +98,7 @@
 		"requiredTech": "Sailing",
 		"uniques": [
 			"Comment [Can undertake a trade mission with City-State, giving a large sum of gold and [15] Influence]",
+			"Comment [If built in a city with a [Workshop], may establish an Internal [Trade Route] in an owned city to provide extra [Production]]",
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [15] Influence <for units without [[Harbor] ability]> <hidden from users>",
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence <for units with [[Harbor] ability]> <hidden from users>",
 			// TODO: Establish Trade Route with a different civ (Route must run over water from one coastal city to another.)
@@ -104,9 +110,13 @@
 			"May enter foreign tiles without open borders",
 			"Uncapturable <hidden from users>",
 			"Never appears as a Barbarian unit <hidden from users>",
-			"[-66]% Gold from Great Merchant trade missions <hidden from users>"
+			"[-66]% Gold from Great Merchant trade missions <hidden from users>",
+			"Gain a free [Food Entrepôt] [in this city] <by consuming this unit> <in [{Your} {Coastal}] cities> <in cities without a [Food Entrepôt]> <for units with [[Granary] ability]> <hidden from users>",
+			"Gain a free [Material Drydock] [in this city] <by consuming this unit> <in [Your] cities> <in cities without a [Material Drydock]> <for units with [[Workshop] ability]> <hidden from users>",
+			"Can Spread Religion <for all movement> <once> <after founding a religion> <for [Arabia] Civilizations> <hidden from users>"
 			// TODO: Within own cities, provide food and production after granary or workshop
-		]
+		],
+		"religiousStrength": 1500
 	},
 
 	// Unique units


### PR DESCRIPTION
- Very hack job implementation of internal trade routes:
	+ Caravans and Cargo Ships built in a city with a Granary or a Workshop will receive a special promotion.
	+ This promotion will allow the unit to establish an unbuilable and unpurchaseable building in your own cities by consuming the unit.
	+ What building you can build depends on the trade unit type, as well as the available promotions.
	+ Internal trade route values: https://www.carlsguides.com/strategy/civilization5/empire/traderoutes.php
	+ Updated Iron Curtain to buff the trade buildings
	+ Known cons compared to actual BNW trade routes:
		* The newly trade unit can be consumed in the same city where it is built (Civ5 BNW doesn't allow a trade unit to trade with the origin city)
		* Cannot establish another internal trade building if one of that exact type already exists (Civ5 BNW allows stacking internal trade routes of same type to a city, as long as you have multiple origin points to send the routes from)
		* Trade building cannot be sold for some reason (i tried), making the Food/Production buff permanent but also preventing you from using the Trade Route slot for something else like using it for gold, or sending a route to another city that needs it more (Civ5 BNW allows rerouting after a certain amount of turns have passed)
- Destroying a trade unit gives 100 Gold to the destroyer (untested, unsure if this works)
- Morocco's UA gives a temporary Gold and Culture buff upon using a trade unit
- Arabian trade units can spread religion with a higher religious strength than a Missionary, but only once
- Added a missing comma to Portugal's json block