### PR TITLE
consulates nerf

### DIFF
--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -296,7 +296,7 @@
 			{
 				"name": "Consulates",
 				"uniques": [
-					"Resting point for Influence with City-States is increased by [20]"
+					"Resting point for Influence with City-States is increased by [15]"
 				],
 				"row": 1,
 				"column": 4

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -296,6 +296,7 @@
 			{
 				"name": "Consulates",
 				"uniques": [
+					// 20 in BNW, but we use 15 in Unciv for balance.
 					"Resting point for Influence with City-States is increased by [15]"
 				],
 				"row": 1,


### PR DESCRIPTION
In BNW, the resting point for CSes upon pledging to protect is reduced to 5; this combined with Consulates nets a resting point of 25, meaning you'd still have to do quests or bribe them to become friends, unlike in Vanilla/G&K.

Since there doesn't seem to be a way to modify the resting point for protection pledges without changing Unciv source code itself, this should do it for now.