### PR TITLE
Make Winged Hussar unique more consise

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -278,7 +278,7 @@
 		"uniques": [
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"[-33]% Strength <when attacking> <vs cities>",
+			"[-33]% Strength <vs cities> <when attacking>",
 			"Consumes [1] [Horses]"
 		],
 		"promotions": [


### PR DESCRIPTION
The Winged Hussar's debuff against cities is written slightly differently to how other mounted units, meaning that the unit has a somewhat confusing description. This change should fix this and make the units description a bit more clear.