### PR TITLE
Added missing commas to Native Tongue event

### DIFF
--- a/jsons/Events.json
+++ b/jsons/Events.json
@@ -588,7 +588,7 @@
 				"uniques": [
 					"Remove [Ancient ruins] improvements from this tile <upon entering a [Ancient ruins] tile> <hidden from users>",
 					"Free [Worker] appears <hidden from users>",
-					"Unavailable <on [Prince] difficulty or higher> <hidden from users>"
+					"Unavailable <on [Prince] difficulty or higher> <hidden from users>",
 					"Unavailable <for units with [[Native Tongue] [squatters willing to work for you] I]> <hidden from users>",
 					"Triggers a [Native Tongue Counter] event <hidden from users>",
 					"[This Unit] gains the [[Native Tongue] [squatters willing to work for you] I] promotion <hidden from users>",
@@ -600,7 +600,7 @@
 				"uniques": [
 					"Remove [Ancient ruins] improvements from this tile <upon entering a [Ancient ruins] tile> <hidden from users>",
 					"Free [Settler] appears <hidden from users>",
-					"Unavailable <on [Prince] difficulty or higher> <hidden from users>"
+					"Unavailable <on [Prince] difficulty or higher> <hidden from users>",
 					"Unavailable <for units with [[Native Tongue] [squatters wishing to settle under your rule] I]> <hidden from users>",
 					"Triggers a [Native Tongue Counter] event <hidden from users>",
 					"[This Unit] gains the [[Native Tongue] [squatters wishing to settle under your rule] I] promotion <hidden from users>",


### PR DESCRIPTION
The missing commas might be the reason why I'm seeing the options to gain a Settler or a Worker, as can be seen here. This is a King difficulty game, meaning they shouldn't show up in the first place.
<img width="1931" height="847" alt="image" src="https://github.com/user-attachments/assets/14d9b9a5-fa7a-4ac8-9135-7f0d5c512fb8" />
