### PR TITLE
Remove duplicate Modern era merchant gold

### DIFF
--- a/jsons/GlobalUniques.json
+++ b/jsons/GlobalUniques.json
@@ -11,7 +11,6 @@
 		"[+32]% Gold from Great Merchant trade missions <during the [Modern era]>",
 		"[+34]% Gold from Great Merchant trade missions <during the [Atomic era]>",
 		"[+37]% Gold from Great Merchant trade missions <during the [Information era]>",
-		"[+38]% Gold from Great Merchant trade missions <during the [Modern era]>",
 		"[+40]% Gold from Great Merchant trade missions <starting from the [Future era]>",
 
 		// Great Admirals can always traverse ocean tiles


### PR DESCRIPTION
GlobalUniques.json had two Great Merchant clauses for the Modern era (+32% and +38%), which stack to +70%; dropping the stray +38% line restores the intended progression.