### PR TITLE
Let Mercenary Army purchase Landsknechts

### DIFF
--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -527,7 +527,8 @@
 			{
 				"name": "Mercenary Army",
 				"uniques": [
-					"Comment [May buy [Landsknecht] units with [Gold] [in your cities]]"
+					"Comment [May buy [Landsknecht] units with [Gold] [in your cities]]",
+					"May buy [Landsknecht] units with [Gold] [in your cities] <hidden from users>"
 				],
 				"row": 1,
 				"column": 4


### PR DESCRIPTION
Landsknecht is `Unbuildable`, which also blocks default Gold purchase in Unciv, so the policy granted nothing; adding the `May buy [Landsknecht] units with [Gold]` unique makes the purchase work as the existing Comment describes. Fixes #215.